### PR TITLE
fix: enforce appropriate length

### DIFF
--- a/base32_lib/base32.py
+++ b/base32_lib/base32.py
@@ -94,13 +94,13 @@ def generate(length=8, split_every=0, checksum=False):
         )
 
     generator = random.SystemRandom()
-    length = length - 2 if checksum else length
+    length_no_checksum = length - 2 if checksum else length
     # takes at most length*5 bits to express, but could take less
-    number = generator.getrandbits(length * 5)
+    number = generator.getrandbits(length_no_checksum * 5)
     return encode(
         number,
         split_every=split_every,
-        min_length=length,  # ensures desired length
+        min_length=length,  # ensures desired length (*including* checksum)
         checksum=checksum
     )
 


### PR DESCRIPTION
The incorrect length was enforced: length without checksum as opposed to length with checksum. That made it so that encoded strings were sometimes shorter than they were supposed to be... but only *sometimes* which made this hard to catch!